### PR TITLE
kmeans_init: replace import sklearn private func

### DIFF
--- a/algorithms/weighted_kmeans.py
+++ b/algorithms/weighted_kmeans.py
@@ -1,5 +1,5 @@
 from sklearn.utils import check_random_state
-from sklearn.cluster.k_means_ import _init_centroids
+from utils.kmeans_init import _init_centroids
 from sklearn.utils.extmath import row_norms
 from algorithms import weighted_kmeans_
 import numpy as np

--- a/coresets/k_means_coreset.py
+++ b/coresets/k_means_coreset.py
@@ -1,9 +1,11 @@
-from sklearn.cluster.k_means_ import _init_centroids
 from sklearn.utils.extmath import row_norms
+from utils.kmeans_init import _init_centroids
 
 from coresets import Coreset
 import numpy as np
 from coresets import sensitivity
+
+
 
 
 class KMeansCoreset(Coreset):
@@ -38,8 +40,8 @@ class KMeansCoreset(Coreset):
 
     def calc_sampling_distribution(self):
         x_squared_norms = row_norms(self.X, squared=True)
-        centers = _init_centroids(self.X, self.n_clusters, self.init, random_state=self.random_state,
-                                  x_squared_norms=x_squared_norms)
+        centers = _init_centroids(self.X, self.n_clusters, self.init, x_squared_norms=x_squared_norms,
+                                  random_state=self.random_state)
         sens = sensitivity.kmeans_sensitivity(self.X, self.w, centers, max(np.log(self.n_clusters), 1))
         self.p = sens / np.sum(sens)
 

--- a/coresets/k_means_coreset.py
+++ b/coresets/k_means_coreset.py
@@ -6,8 +6,6 @@ import numpy as np
 from coresets import sensitivity
 
 
-
-
 class KMeansCoreset(Coreset):
     """
     Class for generating k-Means coreset based on the sensitivity framework

--- a/utils/kmeans_init.py
+++ b/utils/kmeans_init.py
@@ -1,0 +1,297 @@
+"""
+Copying the necessary code from:
+https://github.com/scikit-learn/scikit-learn/tree/8d295fbdc77c859b2ee811b2ee0588c48960bf6a
+to fix the braking dependencies
+"""
+
+
+import numpy as np
+import scipy.sparse as sp
+
+from sklearn.utils.extmath import stable_cumsum, safe_sparse_dot, row_norms
+from sklearn.utils import gen_batches, check_array
+
+
+def _euclidean_distances_upcast(X, XX=None, Y=None, YY=None, batch_size=None):
+    """Euclidean distances between X and Y.
+    Assumes X and Y have float32 dtype.
+    Assumes XX and YY have float64 dtype or are None.
+    X and Y are upcast to float64 by chunks, which size is chosen to limit
+    memory increase by approximately 10% (at least 10MiB).
+    """
+    n_samples_X = X.shape[0]
+    n_samples_Y = Y.shape[0]
+    n_features = X.shape[1]
+
+    distances = np.empty((n_samples_X, n_samples_Y), dtype=np.float32)
+
+    if batch_size is None:
+        x_density = X.nnz / np.prod(X.shape) if sp.issparse(X) else 1
+        y_density = Y.nnz / np.prod(Y.shape) if sp.issparse(Y) else 1
+
+        # Allow 10% more memory than X, Y and the distance matrix take (at
+        # least 10MiB)
+        maxmem = max(
+            (
+                (x_density * n_samples_X + y_density * n_samples_Y) * n_features
+                + (x_density * n_samples_X * y_density * n_samples_Y)
+            )
+            / 10,
+            10 * 2**17,
+        )
+
+        # The increase amount of memory in 8-byte blocks is:
+        # - x_density * batch_size * n_features (copy of chunk of X)
+        # - y_density * batch_size * n_features (copy of chunk of Y)
+        # - batch_size * batch_size (chunk of distance matrix)
+        # Hence x² + (xd+yd)kx = M, where x=batch_size, k=n_features, M=maxmem
+        #                                 xd=x_density and yd=y_density
+        tmp = (x_density + y_density) * n_features
+        batch_size = (-tmp + np.sqrt(tmp**2 + 4 * maxmem)) / 2
+        batch_size = max(int(batch_size), 1)
+
+    x_batches = gen_batches(n_samples_X, batch_size)
+
+    for i, x_slice in enumerate(x_batches):
+        X_chunk = X[x_slice].astype(np.float64)
+        if XX is None:
+            XX_chunk = row_norms(X_chunk, squared=True)[:, np.newaxis]
+        else:
+            XX_chunk = XX[x_slice]
+
+        y_batches = gen_batches(n_samples_Y, batch_size)
+
+        for j, y_slice in enumerate(y_batches):
+            if X is Y and j < i:
+                # when X is Y the distance matrix is symmetric so we only need
+                # to compute half of it.
+                d = distances[y_slice, x_slice].T
+
+            else:
+                Y_chunk = Y[y_slice].astype(np.float64)
+                if YY is None:
+                    YY_chunk = row_norms(Y_chunk, squared=True)[np.newaxis, :]
+                else:
+                    YY_chunk = YY[:, y_slice]
+
+                d = -2 * safe_sparse_dot(X_chunk, Y_chunk.T, dense_output=True)
+                d += XX_chunk
+                d += YY_chunk
+
+            distances[x_slice, y_slice] = d.astype(np.float32, copy=False)
+
+    return distances
+
+
+def _euclidean_distances(X, Y, X_norm_squared=None, Y_norm_squared=None, squared=False):
+    """Computational part of euclidean_distances
+    Assumes inputs are already checked.
+    If norms are passed as float32, they are unused. If arrays are passed as
+    float32, norms needs to be recomputed on upcast chunks.
+    TODO: use a float64 accumulator in row_norms to avoid the latter.
+    """
+    if X_norm_squared is not None:
+        if X_norm_squared.dtype == np.float32:
+            XX = None
+        else:
+            XX = X_norm_squared.reshape(-1, 1)
+    elif X.dtype == np.float32:
+        XX = None
+    else:
+        XX = row_norms(X, squared=True)[:, np.newaxis]
+
+    if Y is X:
+        YY = None if XX is None else XX.T
+    else:
+        if Y_norm_squared is not None:
+            if Y_norm_squared.dtype == np.float32:
+                YY = None
+            else:
+                YY = Y_norm_squared.reshape(1, -1)
+        elif Y.dtype == np.float32:
+            YY = None
+        else:
+            YY = row_norms(Y, squared=True)[np.newaxis, :]
+
+    if X.dtype == np.float32:
+        # To minimize precision issues with float32, we compute the distance
+        # matrix on chunks of X and Y upcast to float64
+        distances = _euclidean_distances_upcast(X, XX, Y, YY)
+    else:
+        # if dtype is already float64, no need to chunk and upcast
+        distances = -2 * safe_sparse_dot(X, Y.T, dense_output=True)
+        distances += XX
+        distances += YY
+    np.maximum(distances, 0, out=distances)
+
+    # Ensure that distances between vectors and themselves are set to 0.0.
+    # This may not be the case due to floating point rounding errors.
+    if X is Y:
+        np.fill_diagonal(distances, 0)
+
+    return distances if squared else np.sqrt(distances, out=distances)
+
+
+def _kmeans_plusplus(X, n_clusters, x_squared_norms, random_state, n_local_trials=None):
+    """Computational component for initialization of n_clusters by
+    k-means++. Prior validation of data is assumed.
+    Parameters
+    ----------
+    X : {ndarray, sparse matrix} of shape (n_samples, n_features)
+        The data to pick seeds for.
+    n_clusters : int
+        The number of seeds to choose.
+    x_squared_norms : ndarray of shape (n_samples,)
+        Squared Euclidean norm of each data point.
+    random_state : RandomState instance
+        The generator used to initialize the centers.
+        See :term:`Glossary <random_state>`.
+    n_local_trials : int, default=None
+        The number of seeding trials for each center (except the first),
+        of which the one reducing inertia the most is greedily chosen.
+        Set to None to make the number of trials depend logarithmically
+        on the number of seeds (2+log(k)); this is the default.
+    Returns
+    -------
+    centers : ndarray of shape (n_clusters, n_features)
+        The initial centers for k-means.
+    indices : ndarray of shape (n_clusters,)
+        The index location of the chosen centers in the data array X. For a
+        given index and center, X[index] = center.
+    """
+    n_samples, n_features = X.shape
+
+    centers = np.empty((n_clusters, n_features), dtype=X.dtype)
+
+    # Set the number of local seeding trials if none is given
+    if n_local_trials is None:
+        # This is what Arthur/Vassilvitskii tried, but did not report
+        # specific results for other than mentioning in the conclusion
+        # that it helped.
+        n_local_trials = 2 + int(np.log(n_clusters))
+
+    # Pick first center randomly and track index of point
+    center_id = random_state.randint(n_samples)
+    indices = np.full(n_clusters, -1, dtype=int)
+    if sp.issparse(X):
+        centers[0] = X[center_id].toarray()
+    else:
+        centers[0] = X[center_id]
+    indices[0] = center_id
+
+    # Initialize list of closest distances and calculate current potential
+    closest_dist_sq = _euclidean_distances(
+        centers[0, np.newaxis], X, Y_norm_squared=x_squared_norms, squared=True
+    )
+    current_pot = closest_dist_sq.sum()
+
+    # Pick the remaining n_clusters-1 points
+    for c in range(1, n_clusters):
+        # Choose center candidates by sampling with probability proportional
+        # to the squared distance to the closest existing center
+        rand_vals = random_state.uniform(size=n_local_trials) * current_pot
+        candidate_ids = np.searchsorted(stable_cumsum(closest_dist_sq), rand_vals)
+        # XXX: numerical imprecision can result in a candidate_id out of range
+        np.clip(candidate_ids, None, closest_dist_sq.size - 1, out=candidate_ids)
+
+        # Compute distances to center candidates
+        distance_to_candidates = _euclidean_distances(
+            X[candidate_ids], X, Y_norm_squared=x_squared_norms, squared=True
+        )
+
+        # update closest distances squared and potential for each candidate
+        np.minimum(closest_dist_sq, distance_to_candidates, out=distance_to_candidates)
+        candidates_pot = distance_to_candidates.sum(axis=1)
+
+        # Decide which candidate is the best
+        best_candidate = np.argmin(candidates_pot)
+        current_pot = candidates_pot[best_candidate]
+        closest_dist_sq = distance_to_candidates[best_candidate]
+        best_candidate = candidate_ids[best_candidate]
+
+        # Permanently add best center candidate found in local tries
+        if sp.issparse(X):
+            centers[c] = X[best_candidate].toarray()
+        else:
+            centers[c] = X[best_candidate]
+        indices[c] = best_candidate
+
+    return centers, indices
+
+
+def _is_arraylike(x):
+    """Returns whether the input is array-like."""
+    return hasattr(x, "__len__") or hasattr(x, "shape") or hasattr(x, "__array__")
+
+
+def _is_arraylike_not_scalar(array):
+    """Return True if array is array-like and not a scalar"""
+    return _is_arraylike(array) and not np.isscalar(array)
+
+
+def _validate_center_shape(X, n_clusters, centers):
+    """Check if centers is compatible with X and n_clusters."""
+    if centers.shape[0] != n_clusters:
+        raise ValueError(
+            f"The shape of the initial centers {centers.shape} does not "
+            f"match the number of clusters {n_clusters}."
+        )
+    if centers.shape[1] != X.shape[1]:
+        raise ValueError(
+            f"The shape of the initial centers {centers.shape} does not "
+            f"match the number of features of the data {X.shape[1]}."
+        )
+
+
+def _init_centroids(X, n_clusters, init, x_squared_norms, random_state, init_size=None):
+    """Compute the initial centroids.
+    Parameters
+    ----------
+    X : {ndarray, sparse matrix} of shape (n_samples, n_features)
+        The input samples.
+    n_clusters : int
+        Number of clusters
+    init : {'k-means++', 'random'}, callable or ndarray of shape \
+            (n_clusters, n_features)
+        Method for initialization.
+    x_squared_norms : ndarray of shape (n_samples,)
+        Squared euclidean norm of each data point. Pass it if you have it
+        at hands already to avoid it being recomputed here.
+    random_state : RandomState instance
+        Determines random number generation for centroid initialization.
+        See :term:`Glossary <random_state>`.
+    init_size : int, default=None
+        Number of samples to randomly sample for speeding up the
+        initialization (sometimes at the expense of accuracy).
+    Returns
+    -------
+    centers : ndarray of shape (n_clusters, n_features)
+    """
+    n_samples = X.shape[0]
+    if init_size is not None and init_size < n_samples:
+        init_indices = random_state.randint(0, n_samples, init_size)
+        X = X[init_indices]
+        x_squared_norms = x_squared_norms[init_indices]
+        n_samples = X.shape[0]
+
+    if isinstance(init, str) and init == "k-means++":
+        centers, _ = _kmeans_plusplus(
+            X,
+            n_clusters,
+            random_state=random_state,
+            x_squared_norms=x_squared_norms,
+        )
+    elif isinstance(init, str) and init == "random":
+        seeds = random_state.permutation(n_samples)[:n_clusters]
+        centers = X[seeds]
+    elif _is_arraylike_not_scalar(init):
+        centers = init
+    elif callable(init):
+        centers = init(X, n_clusters, random_state=random_state)
+        centers = check_array(centers, dtype=X.dtype, copy=False, order="C")
+        _validate_center_shape(X, n_clusters, centers)
+
+    if sp.issparse(centers):
+        centers = centers.toarray()
+
+    return centers


### PR DESCRIPTION
The code was importing `_init_centroids` from `sklearn.cluster.k_means_` module which is no longer available after sklearn 0.22. This commit adds the required code while parsing the dependencies. Changes pass tests for the affected module.

Also, resolves https://github.com/zalanborsos/coresets/issues/2